### PR TITLE
Fix formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ mimic
 Mimic Is Monitoring Information Concisely
 
 Node page
-The node page is constructed of the following files called by /node.php and are stored in /node
+---------
 
+The node page is constructed of the following files called by `/node.php` and are stored in `/node`
+
+```
 node-getName.inc.php                      # Gets and formats the name of the node.
 node-header.inc.php                       # Displays header info and links.
 node-nagios.inc.php                       # Calls and displays Nagios information.
@@ -18,3 +21,4 @@ node-magdb.inc.php                        # Calls and shows System, Rack Power, 
 node-aquilon.inc.php                      # Displays Aquilon data.
 node-pakiti2-json.inc.php                 # Displays Pakiti data.
   |_ node-pakiti2-json.py                 # Connects to WEBHOST.
+```


### PR DESCRIPTION
GitHub doesn't use a fixed width font by default when displaying Markdown, so the formatting used in #4 in `README.md` is a bit wonky. :dizzy_face:

Changes:
- Headerize "Node page" header.
- Make part that requires fixed width font a code block.
- Add fixed width formatting to file/dir names.
