### PR TITLE
Ignore callbacks if view changes

### DIFF
--- a/index.php
+++ b/index.php
@@ -11,7 +11,12 @@ require 'inc/header.inc.php';
   $('#farm').html(msg_loading);
 
   function update() {
+    var requested_view = view;
     var request = $.get('views/view-'+view+'.php').done(function(d) {
+      if (view != requested_view) {
+        console.log("Ignoring callback for "+requested_view+", current view is "+view);
+        return;
+      }
       $("#farm").html(d);
       locateNode($('#inLocate').val());
       $('span.node').tooltip({html: true, container: '#farm', placement: 'bottom'});


### PR DESCRIPTION
Ignore callbacks if the view has been changed after the inital request was made but before the callback has happened.

This occurs frequently with views that are slow to generate (e.g. the cloud view).

Fixes #14.
