### PR TITLE
Concat fix/update & version number update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "mimic",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "homepage": "https://github.com/stfc/mimic",
     "authors": [
         "Callum Williams",

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
                 options: {
                     separator: ';',
                 },
-                src: ['assets/js/bower.js', 'assets/js/key.js', 'assets/js/monitor.js', 'assets/js/plugins.js', 'assets/js/tooltip.js'],
+                src: ['assets/dist/js/bower.js', 'assets/js/key.js', 'assets/js/monitor.js', 'assets/js/plugins.js', 'assets/js/tooltip.js'],
                 dest: 'assets/dist/js/script.js'
             },
             css: {

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -20,11 +20,22 @@ module.exports = function(grunt) {
                 options: {
                     separator: ';',
                 },
-                src: ['assets/dist/js/bower.js', 'assets/js/key.js', 'assets/js/monitor.js', 'assets/js/plugins.js', 'assets/js/tooltip.js'],
+                src: [
+                    'assets/dist/js/bower.js',
+                    'assets/js/key.js',
+                    'assets/js/monitor.js',
+                    'assets/js/plugins.js',
+                    'assets/js/tooltip.js',
+                    'bower_components/masonry/dist/masonry.pkgd.js'
+                ],
                 dest: 'assets/dist/js/script.js'
             },
             css: {
-                src: ['assets/css/style.css', 'assets/css/tooltip.css', 'bower_components/jquery.cookiebar/jquery.cookiebar.css'],
+                src: [
+                    'assets/css/style.css',
+                    'assets/css/tooltip.css',
+                    'bower_components/jquery.cookiebar/jquery.cookiebar.css'
+                ],
                 dest: 'assets/dist/css/style.css'
             }
         },

--- a/header.php
+++ b/header.php
@@ -24,7 +24,6 @@ include('config/plugins.inc.php');
     <link rel="stylesheet" href="assets/dist/css/style.min.css">
     <link href='https://fonts.googleapis.com/css?family=Emilys+Candy' rel='stylesheet' type='text/css'>
     <script type="text/javascript" src="assets/dist/js/script.min.js"></script>
-    <script type="text/javascript" src="bower_components/masonry/dist/masonry.pkgd.js"></script>
 </head>
 <body>
     <?php

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimic",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Mimic is a framework for building visual aggregations of data from many different monitoring systems as highly visual web application.",
   "main": "index.php",
   "dependencies": {},
@@ -12,7 +12,8 @@
     "grunt-contrib-cssmin": "~0.13.0",
     "grunt-contrib-copy": "~0.8.1",
     "grunt-uncss": "~0.4.3",
-    "grunt-contrib-concat": "~0.5.1"
+    "grunt-contrib-concat": "~0.5.1",
+    "grunt-cli": "~0.1.13"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
- Concat was looking for bower's output `bower.js` in `assets/js/` when it should have been looking in `assets/dist/js/`.
- Due to issues with the way Bower calls Masonry, the Masonry file was being called directly from `/header.php`. It is now added during the concat process that swishes the users js files with `bower.js`. This is a good workaround and the end result is the same, but it would still be nice to find a way to let Bower deal with it from the start.
- Mimic updated to 1.3.0.
- grunt-cli added to `package.json`.
