### PR TITLE
Bump bower to at least 1.8.8 to address CVE-2019-5484

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "grunt-uncss": "~0.4.3",
     "grunt-contrib-concat": "~0.5.1",
     "grunt-cli": "~0.1.13",
-    "bower": "~1.7.9"
+    "bower": ">=1.8.8"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Doesn't seem to affect builds in any way.