### PR TITLE
Fix allocated state colour

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -407,13 +407,13 @@ NODE STATE COLOURS/IMAGES
 }
 
 .inuse,
-.allocated,
 .completing,
 .mixed {
   background-color: #6dd;
 }
 
 .full,
+.allocated,
 .relocating {
   background-color: #09d;
 }


### PR DESCRIPTION
Allocated in slurm means full, so use the full colour instead of the inuse colour