### PR TITLE
Update grunt and other dependencies

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,20 +1,5 @@
 module.exports = function(grunt) {
     grunt.initConfig({
-        bower_concat: {
-            all: {
-                dest: 'assets/dist/js/bower.js',
-                exclude: [
-                    'jquery-ui',
-                    'masonry'
-                ],
-                mainFiles: {
-                    'outlayer': [
-                        'bower_components/outlayer/item.js',
-                        'bower_components/outlayer/outlayer.js'
-                    ]
-                }
-            }
-        },
         concat: {
             main: {
                 options: {
@@ -87,7 +72,6 @@ module.exports = function(grunt) {
         }
     });
     grunt.registerTask('buildmimic', [
-        'bower_concat',
         'concat',
         'uglify',
         'cssmin',

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "grunt-contrib-uglify": "~0.9.2",
     "grunt-contrib-cssmin": "~0.13.0",
     "grunt-contrib-copy": "~0.8.1",
-    "grunt-uncss": "~0.4.3",
+    "grunt-uncss": ">=0.10.1",
     "grunt-contrib-concat": "~0.5.1",
     "grunt-cli": "~0.1.13",
     "bower": ">=1.8.8"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "load-grunt-tasks": "~3.2.0",
     "grunt-contrib-uglify": ">=5.0.1",
     "grunt-contrib-cssmin": ">=4.0.0",
-    "grunt-contrib-copy": "~0.8.1",
+    "grunt-contrib-copy": ">=1.0.0",
     "grunt-uncss": ">=0.10.1",
     "grunt-contrib-concat": "~0.5.1",
     "grunt-cli": ">=1.3.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "grunt": ">=1.3.0",
     "load-grunt-tasks": "~3.2.0",
-    "grunt-contrib-uglify": "~0.9.2",
+    "grunt-contrib-uglify": ">=5.0.1",
     "grunt-contrib-cssmin": "~0.13.0",
     "grunt-contrib-copy": "~0.8.1",
     "grunt-uncss": ">=0.10.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.php",
   "dependencies": {},
   "devDependencies": {
-    "grunt": "~0.4.5",
+    "grunt": ">=1.3.0",
     "load-grunt-tasks": "~3.2.0",
     "grunt-bower-concat": "~0.5.0",
     "grunt-contrib-uglify": "~0.9.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "grunt": ">=1.3.0",
     "load-grunt-tasks": "~3.2.0",
     "grunt-contrib-uglify": ">=5.0.1",
-    "grunt-contrib-cssmin": "~0.13.0",
+    "grunt-contrib-cssmin": ">=4.0.0",
     "grunt-contrib-copy": "~0.8.1",
     "grunt-uncss": ">=0.10.1",
     "grunt-contrib-concat": "~0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mimic",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Mimic is a framework for building visual aggregations of data from many different monitoring systems as highly visual web application.",
   "main": "index.php",
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": ">=1.3.0",
-    "load-grunt-tasks": "~3.2.0",
+    "load-grunt-tasks": ">=5.1.0",
     "grunt-contrib-uglify": ">=5.0.1",
     "grunt-contrib-cssmin": ">=4.0.0",
     "grunt-contrib-copy": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "grunt-contrib-cssmin": ">=4.0.0",
     "grunt-contrib-copy": ">=1.0.0",
     "grunt-uncss": ">=0.10.1",
-    "grunt-contrib-concat": "~0.5.1",
+    "grunt-contrib-concat": ">=1.0.1",
     "grunt-cli": ">=1.3.2",
     "bower": ">=1.8.8"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "devDependencies": {
     "grunt": ">=1.3.0",
     "load-grunt-tasks": "~3.2.0",
-    "grunt-bower-concat": "~0.5.0",
     "grunt-contrib-uglify": "~0.9.2",
     "grunt-contrib-cssmin": "~0.13.0",
     "grunt-contrib-copy": "~0.8.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "grunt-contrib-copy": "~0.8.1",
     "grunt-uncss": ">=0.10.1",
     "grunt-contrib-concat": "~0.5.1",
-    "grunt-cli": "~0.1.13",
+    "grunt-cli": ">=1.3.2",
     "bower": ">=1.8.8"
   },
   "repository": {


### PR DESCRIPTION
While this removes the entire `bower_concat` build step, it produces no difference in output as `outlayer` was apparently unused.