### PR TITLE
pylint: Drop Python 2.7 and add 3.9

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["2.7", "3.6"]
+        python-version: ["3.6", "3.9"]
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Rocky 9 ships Python 3.9.