### PR TITLE
Group CPUs on batch node display

### DIFF
--- a/assets/css/info.css
+++ b/assets/css/info.css
@@ -447,6 +447,15 @@ div#pakiti2-json span.standard {
   color: #4e9a06;
 }
 
+div.visual-slots {
+  background-image: linear-gradient(90deg, rgba(0, 0, 0, .333) 1px, transparent 1px);
+  background-size: 56px 3px;
+  background-repeat: repeat-x;
+  background-position-y: bottom;
+  padding-right: 1px;
+  width: fit-content;
+}
+
 /* PBS Nodetypes */
 div.deadfree,
 div.deadinuse,

--- a/node/node-batchsystem.inc.php
+++ b/node/node-batchsystem.inc.php
@@ -47,12 +47,30 @@ class pBatchSystem
         if ($state == "offline" or $state == "down") {
           $dead = "dead";
         }
+        $divisor = 32;
+        $j = 0;
         for($i = 0; $i < $job_number; $i++) {
+          if ($j % $divisor == 0) {
+            $state_visual = $state_visual . '<div class="visual-slots">';
+          }
           $state_visual = $state_visual . '<div class="cpu '.$dead.'inuse"></div>';
+          if ($j % $divisor == $divisor - 1) {
+            $state_visual = $state_visual . '</div>';
+          }
+          $j++;
         }
         for($i = 0; $i < ($slots - $job_number); $i++) {
+          if ($j % $divisor == 0) {
+            $state_visual = $state_visual . '<div class="visual-slots">';
+          }
           $state_visual = $state_visual . '<div class="cpu '.$dead.'free"></div>';
+          if ($j % $divisor == $divisor - 1) {
+            $state_visual = $state_visual . '</div>';
+          }
+          $j++;
         }
+        unset($j);
+        unset($divisor);
         echo "         <dt>Visual State</dt><dd>$state_visual</dd>\n";
 
         echo    "      <dt>Properties</dt><dd>".$prop."</dd>\n";


### PR DESCRIPTION
This became necessary when we got out first 128 core nodes.

Display a tick mark every 8 cores.

e.g.

![image](https://github.com/stfc/mimic/assets/323309/52877cf5-6935-4967-a406-4a631638844b)
