### PR TITLE
node-aquilon: Hide trailing host features

### DIFF
--- a/node/node-aquilon.inc.php
+++ b/node/node-aquilon.inc.php
@@ -35,7 +35,9 @@ class pAquilon {
           $val = preg_replace('/(.*) &lt;(.+@.+)&gt;/', '<a href="mailto:$2">$1</a>', $val);
           $val = str_replace("[", "<em>[", $val);
           $val = str_replace("]", "]</em>", $val);
-          echo "<li><strong>$key</strong> &ndash; $val";
+          if ($key != '  Host Feature') {
+            echo "<li><strong>$key</strong> &ndash; $val";
+          }
         }
         $p_in = $info_data;
       }


### PR DESCRIPTION
For legacy reasons the broker lists host features twice.

The first time is under the personality or archetype, the second at the end of the report. These are easy to identify by indentation level, so just ignore these.